### PR TITLE
Expense payment improvements

### DIFF
--- a/app/Http/Controllers/WorkdaySyncController.php
+++ b/app/Http/Controllers/WorkdaySyncController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Jobs\CancelExpensePayments;
 use App\Models\Attachment;
 use App\Models\ExpensePayment;
 use App\Models\ExpenseReport;
@@ -127,6 +128,8 @@ class WorkdaySyncController extends Controller
     public function syncComplete(): JsonResponse
     {
         Cache::put('last_workday_sync', Carbon::now()->unix());
+
+        CancelExpensePayments::dispatch();
 
         return response()->json(
             [

--- a/app/Http/Controllers/WorkdaySyncController.php
+++ b/app/Http/Controllers/WorkdaySyncController.php
@@ -33,10 +33,7 @@ class WorkdaySyncController extends Controller
         $unreconciled_payment = ExpenseReport::whereHas(
             'expensePayment',
             static function (EloquentBuilder $query): void {
-                $query->where('reconciled', '=', false)
-                    ->whereHas('payTo', static function (EloquentBuilder $query): void {
-                        $query->whereDoesntHave('user');
-                    });
+                $query->where('reconciled', '=', false);
             }
         )
             ->get()

--- a/app/Jobs/CancelExpensePayments.php
+++ b/app/Jobs/CancelExpensePayments.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\ExpensePayment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+
+class CancelExpensePayments implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        ExpensePayment::whereDoesntHave('expenseReports')
+            ->update(['status' => 'Canceled']);
+    }
+}

--- a/app/Nova/ExpensePayment.php
+++ b/app/Nova/ExpensePayment.php
@@ -174,6 +174,23 @@ class ExpensePayment extends Resource
      */
     public function actions(NovaRequest $request): array
     {
+        $resourceId = $request->resourceId ?? $request->resources;
+
+        if ($resourceId === null) {
+            return [];
+        }
+
+        $payment = \App\Models\ExpensePayment::find($resourceId);
+
+        if (
+            $payment->status !== 'Complete' ||
+            $payment->reconciled !== true ||
+            $payment->bank_transaction_id === null ||
+            $payment->bankTransaction->transaction_posted_at === null
+        ) {
+            return [];
+        }
+
         return [
             SyncExpensePaymentToQuickBooks::make()
                 ->canSee(static fn (NovaRequest $request): bool => $request->user()->can('access-quickbooks'))

--- a/app/Policies/ExpensePaymentPolicy.php
+++ b/app/Policies/ExpensePaymentPolicy.php
@@ -41,9 +41,7 @@ class ExpensePaymentPolicy
      */
     public function update(User $user, ExpensePayment $expensePayment): bool
     {
-        return $user->can('access-workday') &&
-            ! $expensePayment->reconciled &&
-            $expensePayment->status === 'Complete';
+        return false;
     }
 
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,6 +32,7 @@ parameters:
     - '#Called ''modelKeys'' on Laravel collection, but could have been retrieved as a query\.#'
     - '#Cannot access offset .+ on mixed\.#'
     - '#Cannot access offset 0 on array\|float\|int\|string\|null\.#'
+    - '#Cannot access property \$[a-zA-Z_]+ on App\\Models\\[a-zA-Z]+\|Illuminate\\Database\\Eloquent\\Collection<int, App\\Models\\[a-zA-Z]+>\|null\.#'
     - '#Cannot access property \$[a-zA-Z_]+ on App\\Models\\[a-zA-Z]+\|null\.#'
     - '#Cannot call method addDays\(\) on Illuminate\\Support\\Carbon\|null\.#'
     - '#Cannot call method can\(\) on App\\Models\\User\|null\.#'


### PR DESCRIPTION
- Disable QuickBooks sync for `ExpensePayment`s that are canceled, unreconciled, not matched to a `BankTransaction`, or where the `BankTransaction` is not yet posted - closes #34
- Sync all unreconciled `ExpensePayment`s - closes #35
- Automatically mark `ExpensePayment`s as canceled if they have no associated `ExpenseReport`s - closes #39 
    - Also disable editing `ExpensePayment`s as this was the only reason to manually edit them previously