### PR TITLE
Add support for attachments on Engage requests

### DIFF
--- a/app/Http/Controllers/EngageAttachmentController.php
+++ b/app/Http/Controllers/EngageAttachmentController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UploadEngageAttachment;
+use App\Models\Attachment;
+use App\Models\EngagePurchaseRequest;
+use Illuminate\Http\JsonResponse;
+
+class EngageAttachmentController extends Controller
+{
+    /**
+     * Store a newly uploaded attachment.
+     */
+    public function store(EngagePurchaseRequest $purchase_request, UploadEngageAttachment $request): JsonResponse
+    {
+        $file = $request->file('attachment');
+
+        $attachment = Attachment::create([
+            'attachable_type' => $purchase_request->getMorphClass(),
+            'attachable_id' => $purchase_request->id,
+            'filename' => 'engage/'.$request['documentId'].'/'.$file->getClientOriginalName(),
+            'engage_document_id' => $request['documentId'],
+        ]);
+
+        $file->storeAs('engage/'.$request['documentId'], $file->getClientOriginalName());
+
+        $attachment->searchable();
+
+        return response()->json($attachment);
+    }
+
+    /**
+     * Display the attachment.
+     */
+    public function show(EngagePurchaseRequest $purchase_request, Attachment $attachment): JsonResponse
+    {
+        return response()->json($attachment);
+    }
+}

--- a/app/Http/Controllers/EngagePurchaseRequestController.php
+++ b/app/Http/Controllers/EngagePurchaseRequestController.php
@@ -59,6 +59,8 @@ class EngagePurchaseRequestController extends Controller
             }
         }
 
+        sort($sync_purchase_requests);
+
         return response()->json([
             'requests' => $sync_purchase_requests,
         ]);

--- a/app/Http/Controllers/EngageSyncController.php
+++ b/app/Http/Controllers/EngageSyncController.php
@@ -36,6 +36,8 @@ class EngageSyncController extends Controller
             ->uniqueStrict()
             ->toArray();
 
+        sort($request_engage_ids);
+
         return response()->json([
             'requests' => array_values($request_engage_ids),
         ]);

--- a/app/Http/Controllers/EngageSyncController.php
+++ b/app/Http/Controllers/EngageSyncController.php
@@ -29,17 +29,17 @@ class EngageSyncController extends Controller
             ->get()
             ->pluck('engage_id');
 
-        $request_engage_ids = collect($missing_submitted_by_user)
+        $request_engage_ids = array_values(collect($missing_submitted_by_user)
             ->concat($missing_approved_by_user)
             ->concat($missing_attachments)
             ->concat($not_approved)
             ->uniqueStrict()
-            ->toArray();
+            ->toArray());
 
         sort($request_engage_ids);
 
         return response()->json([
-            'requests' => array_values($request_engage_ids),
+            'requests' => $request_engage_ids,
         ]);
     }
 

--- a/app/Http/Controllers/WorkdayAttachmentController.php
+++ b/app/Http/Controllers/WorkdayAttachmentController.php
@@ -7,12 +7,18 @@ namespace App\Http\Controllers;
 use App\Http\Requests\UploadWorkdayAttachment;
 use App\Jobs\MatchExpenseReport;
 use App\Models\Attachment;
+use App\Models\ExpenseReport;
+use App\Models\ExpenseReportLine;
 use Illuminate\Http\JsonResponse;
 
 class WorkdayAttachmentController extends Controller
 {
-    public function __invoke(Attachment $attachment, UploadWorkdayAttachment $request): JsonResponse
-    {
+    public function __invoke(
+        ExpenseReport $expense_report,
+        ExpenseReportLine $line,
+        Attachment $attachment,
+        UploadWorkdayAttachment $request
+    ): JsonResponse {
         $file = $request->file('attachment');
 
         $file->storeAs('workday/'.$attachment['workday_instance_id'], $file->getClientOriginalName());

--- a/app/Http/Requests/UploadEngageAttachment.php
+++ b/app/Http/Requests/UploadEngageAttachment.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadEngageAttachment extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'attachment' => [
+                'required',
+                'file',
+            ],
+            'documentId' => [
+                'required',
+                'numeric',
+                'integer',
+            ],
+        ];
+    }
+}

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -72,13 +72,14 @@ class Attachment extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'attachable_type',
         'attachable_id',
+        'attachable_type',
+        'engage_document_id',
         'filename',
-        'workday_instance_id',
-        'workday_uploaded_by_worker_id',
-        'workday_uploaded_at',
         'workday_comment',
+        'workday_instance_id',
+        'workday_uploaded_at',
+        'workday_uploaded_by_worker_id',
     ];
 
     /**
@@ -99,14 +100,6 @@ class Attachment extends Model
     public function uploadedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'workday_uploaded_by_worker_id', 'workday_instance_id');
-    }
-
-    /**
-     * Get the route key for the model.
-     */
-    public function getRouteKeyName(): string
-    {
-        return 'workday_instance_id';
     }
 
     /**

--- a/app/Nova/Attachment.php
+++ b/app/Nova/Attachment.php
@@ -50,11 +50,7 @@ class Attachment extends Resource
             ID::make()
                 ->sortable(),
 
-            MorphTo::make('Attachable')
-                ->types([
-                    DocuSignEnvelope::class,
-                    ExpenseReportLine::class,
-                ]),
+            MorphTo::make('Attachable'),
 
             Text::make('Filename')
                 ->displayUsing(static function (string $filename): string {
@@ -78,7 +74,13 @@ class Attachment extends Resource
                 DateTime::make('Uploaded At', 'workday_uploaded_at')
                     ->onlyOnDetail(),
 
-                Text::make('Comment', 'workday_comment'),
+                Text::make('Comment', 'workday_comment')
+                    ->onlyOnDetail(),
+            ]),
+
+            Panel::make('Engage Metadata', [
+                Number::make('Document ID', 'engage_document_id')
+                    ->onlyOnDetail(),
             ]),
 
             Panel::make('Timestamps', [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers;
 use App\Models\Attachment;
 use App\Models\BankTransaction;
 use App\Models\DocuSignEnvelope;
+use App\Models\EngagePurchaseRequest;
 use App\Models\ExpenseReport;
 use App\Models\ExpenseReportLine;
 use App\Observers\AttachmentObserver;
@@ -33,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Relation::morphMap([
             'docusign-envelope' => DocuSignEnvelope::class,
+            'engage-purchase-request' => EngagePurchaseRequest::class,
             'expense-report-line' => ExpenseReportLine::class,
         ]);
 

--- a/database/migrations/2023_10_31_200349_add_engage_document_id_to_attachments.php
+++ b/database/migrations/2023_10_31_200349_add_engage_document_id_to_attachments.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', static function (Blueprint $table): void {
+            $table->unsignedInteger('engage_document_id')->unique()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attachments', static function (Blueprint $table): void {
+            $table->dropColumn('engage_document_id');
+        });
+    }
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -109,7 +109,6 @@ parameters:
     - '#Parameter \#1 \$summary_pdf of static method App\\Models\\DocuSignEnvelope::getEnvelopeUuidFromSummaryPdf\(\) expects string, string\|null given\.#'
     - '#Parameter \#1 \$time of static method Carbon\\Carbon::parse\(\) expects DateTimeInterface\|string\|null, mixed given\.#'
     - '#Parameter \#1 \$timestamp of static method App\\Jobs\\ProcessSensibleOutput::parseDateTimeFromDocuSignFormat\(\) expects string, array\|float\|int\|string given\.#'
-    - '#Parameter \#1 \$timestamp of static method Carbon\\Carbon::createFromTimestamp\(\) expects float\|int\|string, mixed given\.#'
     - '#Parameter \#1 \$title of static method Illuminate\\Support\\Str::slug\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$uri of method GuzzleHttp\\Client::get\(\) expects Psr\\Http\\Message\\UriInterface\|string, mixed given\.#'
     - '#Parameter \#1 \$uri of method GuzzleHttp\\Client::post\(\) expects Psr\\Http\\Message\\UriInterface\|string, mixed given\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -109,6 +109,7 @@ parameters:
     - '#Parameter \#1 \$summary_pdf of static method App\\Models\\DocuSignEnvelope::getEnvelopeUuidFromSummaryPdf\(\) expects string, string\|null given\.#'
     - '#Parameter \#1 \$time of static method Carbon\\Carbon::parse\(\) expects DateTimeInterface\|string\|null, mixed given\.#'
     - '#Parameter \#1 \$timestamp of static method App\\Jobs\\ProcessSensibleOutput::parseDateTimeFromDocuSignFormat\(\) expects string, array\|float\|int\|string given\.#'
+    - '#Parameter \#1 \$timestamp of static method Carbon\\Carbon::createFromTimestamp\(\) expects float\|int\|string, mixed given\.#'
     - '#Parameter \#1 \$title of static method Illuminate\\Support\\Str::slug\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$uri of method GuzzleHttp\\Client::get\(\) expects Psr\\Http\\Message\\UriInterface\|string, mixed given\.#'
     - '#Parameter \#1 \$uri of method GuzzleHttp\\Client::post\(\) expects Psr\\Http\\Message\\UriInterface\|string, mixed given\.#'

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\DocumentDownloadController;
+use App\Http\Controllers\EngageAttachmentController;
 use App\Http\Controllers\EngagePurchaseRequestController;
 use App\Http\Controllers\EngageSyncController;
 use App\Http\Controllers\ExpenseReportController;
@@ -37,7 +38,11 @@ Route::prefix('/v1/workday/')->middleware(['auth:sanctum', 'can:access-workday']
 
     Route::put('expense-reports/{expense_report}/lines/{line}', ExpenseReportLineController::class)->scopeBindings();
 
-    Route::post('attachments/{attachment}', WorkdayAttachmentController::class);
+    Route::post(
+        '/expense-reports/{expense_report}/lines/{line}/attachments/{attachment:workday_instance_id}',
+        WorkdayAttachmentController::class
+    )
+        ->scopeBindings();
 
     Route::get('sync', [WorkdaySyncController::class, 'getResourcesToSync']);
     Route::post('sync', [WorkdaySyncController::class, 'syncComplete']);
@@ -45,6 +50,12 @@ Route::prefix('/v1/workday/')->middleware(['auth:sanctum', 'can:access-workday']
 
 Route::prefix('/v1/engage/')->middleware(['auth:sanctum', 'can:access-engage'])->group(static function () {
     Route::resource('purchase-requests', EngagePurchaseRequestController::class)->only('store', 'update');
+
+    Route::post('/purchase-requests/{purchase_request}/attachments', [EngageAttachmentController::class, 'store']);
+    Route::get(
+        '/purchase-requests/{purchase_request}/attachments/{attachment:engage_document_id}',
+        [EngageAttachmentController::class, 'show']
+    )->scopeBindings();
 
     Route::get('sync', [EngageSyncController::class, 'getRequestsToSync']);
     Route::post('sync', [EngageSyncController::class, 'syncComplete']);


### PR DESCRIPTION
- Move `POST /api/v1/workday/attachments/{attachment}` to `POST /expense-reports/{expense_report}/lines/{line}/attachments/{attachment:workday_instance_id}` for clarity (no functional changes)
- Add `POST /api/v1/engage/purchase-requests/{purchase_request}/attachments` to attach a new file to an existing purchase request
- Add `GET /api/v1/engage/purchase-requests/{purchase_request}/attachments/{attachment:engage_document_id}` for checking whether the server already has an attachment