### PR TITLE
Match expense reports to Engage requests

### DIFF
--- a/app/Exceptions/CouldNotExtractEngagePurchaseRequestNumber.php
+++ b/app/Exceptions/CouldNotExtractEngagePurchaseRequestNumber.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Exception;
+
+class CouldNotExtractEngagePurchaseRequestNumber extends Exception
+{
+}

--- a/app/Models/ExpenseReport.php
+++ b/app/Models/ExpenseReport.php
@@ -158,6 +158,16 @@ class ExpenseReport extends Model
     }
 
     /**
+     * Get the Engage purchase requests for this expense report.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\EngagePurchaseRequest>
+     */
+    public function engagePurchaseRequests(): HasMany
+    {
+        return $this->hasMany(EngagePurchaseRequest::class);
+    }
+
+    /**
      * Get the workday_url attribute to show this ECM in the Workday UI.
      */
     public function getWorkdayUrlAttribute(): string

--- a/app/Nova/Actions/MatchExpenseReport.php
+++ b/app/Nova/Actions/MatchExpenseReport.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 
 namespace App\Nova\Actions;
 
-use App\Models\DocuSignEnvelope;
+use App\Models\EngagePurchaseRequest;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Support\Collection;
@@ -21,7 +21,7 @@ class MatchExpenseReport extends Action
      *
      * @var string
      */
-    public $name = 'Find DocuSign Envelope';
+    public $name = 'Find Engage Request';
 
     /**
      * Indicates if this action is only available on the resource detail view.
@@ -49,20 +49,20 @@ class MatchExpenseReport extends Action
         \App\Jobs\MatchExpenseReport::dispatchSync($expense_report);
 
         try {
-            $envelope = DocuSignEnvelope::whereExpenseReportId($expense_report->id)->sole();
+            $purchase_request = EngagePurchaseRequest::whereExpenseReportId($expense_report->id)->sole();
 
-            return Action::visit(route(
+            return Action::visit(name: route(
                 'nova.pages.detail',
                 [
-                    'resource' => \App\Nova\DocuSignEnvelope::uriKey(),
-                    'resourceId' => $envelope->id,
+                    'resource' => \App\Nova\EngagePurchaseRequest::uriKey(),
+                    'resourceId' => $purchase_request->id,
                 ],
                 false
             ));
         } catch (ModelNotFoundException) {
-            return Action::danger('Could not find matching DocuSign envelope.');
+            return Action::danger('Could not find matching Engage request.');
         } catch (MultipleRecordsFoundException) {
-            return Action::message('Matched more than one DocuSign envelope.');
+            return Action::message('Matched more than one Engage request.');
         }
     }
 

--- a/app/Nova/ExpenseReport.php
+++ b/app/Nova/ExpenseReport.php
@@ -128,7 +128,13 @@ class ExpenseReport extends Resource
 
             HasMany::make('Lines', 'lines', ExpenseReportLine::class),
 
-            HasMany::make('DocuSign Envelopes', 'envelopes', DocuSignEnvelope::class),
+            ...($this->engagePurchaseRequests()->count() === 0 || $this->envelopes()->count() > 0 ? [
+                HasMany::make('DocuSign Envelopes', 'envelopes', DocuSignEnvelope::class),
+            ] : []),
+
+            ...($this->envelopes()->count() === 0 || $this->engagePurchaseRequests()->count() > 0 ? [
+                HasMany::make('Engage Requests', 'engagePurchaseRequests', EngagePurchaseRequest::class),
+            ] : []),
 
             Panel::make('Timestamps', [
                 DateTime::make('Created', 'created_at')

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -103,6 +103,7 @@ parameters:
     - '#Parameter \#1 \$name of static method Laravel\\Nova\\Actions\\Action::openInNewTab\(\) expects string, string\|null given\.#'
     - '#Parameter \#1 \$number of function abs expects float, float\|null given\.#'
     - '#Parameter \#1 \$options of method Laravel\\Nova\\Fields\\Select::options\(\) expects \(callable\(\): iterable<int\|string, array{label: string, group\?: string}\|string\|Stringable>\)\|iterable<int\|string, array{label: string, group\?: string}\|string\|Stringable>, Closure\(\): array given\.#'
+    - '#Parameter \#1 \$pdf_text of static method App\\Models\\EngagePurchaseRequest::getPurchaseRequestNumberFromText\(\) expects string, int\|string\|null given\.#'
     - '#Parameter \#1 \$realmID of method QuickBooksOnline\\API\\Core\\OAuth\\OAuth2\\OAuth2AccessToken::setRealmID\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$string of function base64_decode expects string, mixed given\.#'
     - '#Parameter \#1 \$string of function base64_encode expects string, string\|null given\.#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -49,11 +49,6 @@
                 <file name="app/Nova/Actions/SyncDocuSignEnvelopeToQuickBooks.php"/>
             </errorLevel>
         </UndefinedClass>
-        <InvalidScalarArgument>
-            <errorLevel type="suppress">
-                <file name="app/Jobs/ProcessSensibleOutput.php"/>
-            </errorLevel>
-        </InvalidScalarArgument>
         <InvalidPropertyAssignmentValue>
             <errorLevel type="suppress">
                 <file name="app/Jobs/ProcessSensibleOutput.php"/>
@@ -73,6 +68,7 @@
             <errorLevel type="suppress">
                 <file name="app/Nova/Actions/UploadBankStatement.php"/>
                 <file name="app/Jobs/ProcessSensibleOutput.php"/>
+                <file name="app/Jobs/MatchExpenseReport.php"/>
             </errorLevel>
         </InvalidScalarArgument>
         <UndefinedDocblockClass>


### PR DESCRIPTION
Pretty close to 1-1 swap of what we were doing for DocuSign, though we have some more metadata with Engage.