### PR TITLE
Switch approved column to status

### DIFF
--- a/app/Http/Controllers/EngagePurchaseRequestController.php
+++ b/app/Http/Controllers/EngagePurchaseRequestController.php
@@ -34,7 +34,7 @@ class EngagePurchaseRequestController extends Controller
                 ],
                 [
                     'subject' => $item['name'],
-                    'approved' => $item['status'] === 'Approved',
+                    'status' => $item['status'],
                     'current_step_name' => self::cleanFinanceStageName($item['currentStepName']),
                     'submitted_amount' => $item['submittedAmount'],
                     'submitted_at' => $item['submittedOn'] === null ? null : Carbon::parse($item['submittedOn']),
@@ -50,7 +50,7 @@ class EngagePurchaseRequestController extends Controller
                 if ($purchase_request->submitted_by_user_id === null) {
                     $sync_purchase_requests[] = $purchase_request['engage_id'];
                 } elseif (
-                    $purchase_request->approved && (
+                    $purchase_request->status === 'Approved' && (
                         $purchase_request->approved_by_user_id === null || $purchase_request->approved_at === null
                     )
                 ) {
@@ -78,7 +78,7 @@ class EngagePurchaseRequestController extends Controller
             'engage_request_number' => $request['requestNumber'],
             'subject' => $request['subject'],
             'description' => $request['description'],
-            'approved' => $request['status'] === 'Approved',
+            'status' => $request['status'],
             'current_step_name' => self::cleanFinanceStageName($request['financeStage']['name']),
             'submitted_amount' => $request['submitted']['amount'],
             'submitted_at' => $request['submitted']['date'] === null ? null : Carbon::parse(

--- a/app/Http/Controllers/EngageSyncController.php
+++ b/app/Http/Controllers/EngageSyncController.php
@@ -25,7 +25,7 @@ class EngageSyncController extends Controller
             ->get()
             ->pluck('engage_id');
 
-        $not_approved = EngagePurchaseRequest::where('approved', '=', false)
+        $not_approved = EngagePurchaseRequest::where('status', '!=', 'Approved')
             ->get()
             ->pluck('engage_id');
 

--- a/app/Http/Requests/UpdateEngagePurchaseRequest.php
+++ b/app/Http/Requests/UpdateEngagePurchaseRequest.php
@@ -57,7 +57,7 @@ class UpdateEngagePurchaseRequest extends FormRequest
             'status' => [
                 'required',
                 'string',
-                'in:Approved,Unapproved',
+                'in:Approved,Unapproved,Canceled,Denied',
             ],
             'submitted' => [
                 'required',

--- a/app/Http/Requests/UpsertEngagePurchaseRequests.php
+++ b/app/Http/Requests/UpsertEngagePurchaseRequests.php
@@ -68,7 +68,7 @@ class UpsertEngagePurchaseRequests extends FormRequest
             'items.*.status' => [
                 'required',
                 'string',
-                'in:Approved,Unapproved',
+                'in:Approved,Unapproved,Canceled,Denied',
             ],
             'items.*.currentStepName' => [
                 'required',

--- a/app/Jobs/MatchExpenseReport.php
+++ b/app/Jobs/MatchExpenseReport.php
@@ -52,7 +52,7 @@ class MatchExpenseReport implements ShouldBeUnique, ShouldQueue
             try {
                 $purchase_request = EngagePurchaseRequest::whereApprovedAmount($this->expenseReport->amount)
                     ->whereDoesntHave('expenseReport')
-                    ->where('approved', '=', true)
+                    ->where('status', '=', 'Approved')
                     ->whereDate('approved_at', '<=', $this->expenseReport->created_date)
                     ->where('approved_by_user_id', '=', $this->expenseReport->createdBy->id)
                     ->sole();

--- a/app/Models/DataSource.php
+++ b/app/Models/DataSource.php
@@ -30,6 +30,20 @@ class DataSource extends Model
     protected $primaryKey = 'name';
 
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The "type" of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the model should be timestamped.
      *
      * @var bool

--- a/app/Models/DataSource.php
+++ b/app/Models/DataSource.php
@@ -23,6 +23,13 @@ use Illuminate\Database\Eloquent\Model;
 class DataSource extends Model
 {
     /**
+     * The primary key associated with the table.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'name';
+
+    /**
      * Indicates if the model should be timestamped.
      *
      * @var bool

--- a/app/Models/EngagePurchaseRequest.php
+++ b/app/Models/EngagePurchaseRequest.php
@@ -21,8 +21,8 @@ use Laravel\Scout\Searchable;
  * @property int $engage_request_number
  * @property string $subject
  * @property string|null $description
- * @property bool $approved
  * @property string $current_step_name
+ * @property string $status
  * @property float $submitted_amount
  * @property \Illuminate\Support\Carbon $submitted_at
  * @property int|null $submitted_by_user_id
@@ -58,12 +58,12 @@ use Laravel\Scout\Searchable;
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest query()
- * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereApproved($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereApprovedAmount($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereApprovedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereApprovedByUserId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereCurrentStepName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereStatus($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereDeletedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereDescription($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagePurchaseRequest whereEngageId($value)
@@ -109,7 +109,6 @@ class EngagePurchaseRequest extends Model
         'submitted_at' => 'datetime',
         'approved_at' => 'datetime',
         'deleted_at' => 'datetime',
-        'approved' => 'boolean',
     ];
 
     /**
@@ -118,7 +117,6 @@ class EngagePurchaseRequest extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'approved',
         'approved_amount',
         'approved_at',
         'approved_by_user_id',
@@ -135,6 +133,7 @@ class EngagePurchaseRequest extends Model
         'payee_last_name',
         'payee_state',
         'payee_zip_code',
+        'status',
         'subject',
         'submitted_amount',
         'submitted_at',

--- a/app/Nova/EngagePurchaseRequest.php
+++ b/app/Nova/EngagePurchaseRequest.php
@@ -8,7 +8,6 @@ use App\Nova\Actions\SyncEngagePurchaseRequestToQuickBooks;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
-use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\MorphMany;
@@ -94,6 +93,15 @@ class EngagePurchaseRequest extends Resource
                 ])
                 ->sortable(),
 
+            Badge::make('Status', 'status')
+                ->map([
+                    'Unapproved' => 'info',
+                    'Denied' => 'danger',
+                    'Canceled' => 'danger',
+                    'Approved' => 'success',
+                ])
+                ->sortable(),
+
             Text::make('Subject'),
 
             Text::make('Description')
@@ -156,9 +164,6 @@ class EngagePurchaseRequest extends Resource
             ]),
 
             Panel::make('Approval', [
-                Boolean::make('Approved')
-                    ->onlyOnDetail(),
-
                 Currency::make('Approved Amount')
                     ->onlyOnDetail(),
 
@@ -234,7 +239,7 @@ class EngagePurchaseRequest extends Resource
         if (
             $engageRequest->quickbooks_invoice_id !== null ||
             $engageRequest->quickbooks_invoice_document_number !== null ||
-            ! $engageRequest->approved ||
+            $engageRequest->status !== 'Approved' ||
             $engageRequest->current_step_name !== 'Check Request Sent'
         ) {
             return [];

--- a/database/migrations/2023_11_10_183002_replace_approved_column_with_status_in_engage_purchase_requests_table.php
+++ b/database/migrations/2023_11_10_183002_replace_approved_column_with_status_in_engage_purchase_requests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('engage_purchase_requests', static function (Blueprint $table): void {
+            $table->string('status');
+            $table->dropColumn('approved');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('engage_purchase_requests', static function (Blueprint $table): void {
+            $table->dropColumn('status');
+            $table->boolean('approved');
+        });
+    }
+};


### PR DESCRIPTION
My initial guess was the `status` field in Engage only had two states; it turns out there are (at least) four.