### PR TITLE
Update lenses and metrics for Engage

### DIFF
--- a/app/Models/FiscalYear.php
+++ b/app/Models/FiscalYear.php
@@ -66,6 +66,16 @@ class FiscalYear extends Model
     }
 
     /**
+     * Get the Engage purchase requests for this fiscal year.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\EngagePurchaseRequest>
+     */
+    public function engagePurchaseRequests(): HasMany
+    {
+        return $this->hasMany(EngagePurchaseRequest::class);
+    }
+
+    /**
      * Get the expense reports for this fiscal year.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany<\App\Models\ExpenseReport>

--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -8,7 +8,7 @@ use App\Nova\Metrics\AverageDaysToApproveExpenseReport;
 use App\Nova\Metrics\AverageDaysToCreateExpenseReport;
 use App\Nova\Metrics\AverageDaysToPayExpenseReport;
 use App\Nova\Metrics\AverageDaysToReconcileExpensePayment;
-use App\Nova\Metrics\DocuSignEnvelopesMissingExpenseReports;
+use App\Nova\Metrics\EngagePurchaseRequestsMissingExpenseReports;
 use App\Nova\Metrics\ExpensePaymentsPendingReconciliation;
 use App\Nova\Metrics\ExpenseReportsPendingApproval;
 use App\Nova\Metrics\ExpenseReportsPendingPayment;
@@ -32,7 +32,7 @@ class Main extends Dashboard
     public function cards(): array
     {
         return [
-            DocuSignEnvelopesMissingExpenseReports::make()
+            EngagePurchaseRequestsMissingExpenseReports::make()
                 ->width('1/4'),
             ExpenseReportsPendingApproval::make()
                 ->width('1/4'),

--- a/app/Nova/DocuSignEnvelope.php
+++ b/app/Nova/DocuSignEnvelope.php
@@ -6,8 +6,6 @@ declare(strict_types=1);
 
 namespace App\Nova;
 
-use App\Nova\Lenses\ReimbursementsMissingExpenseReports;
-use App\Nova\Lenses\ReimbursementsMissingInvoices;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
@@ -254,10 +252,7 @@ class DocuSignEnvelope extends Resource
      */
     public function lenses(NovaRequest $request): array
     {
-        return [
-            ReimbursementsMissingExpenseReports::make(),
-            ReimbursementsMissingInvoices::make(),
-        ];
+        return [];
     }
 
     /**

--- a/app/Nova/EngagePurchaseRequest.php
+++ b/app/Nova/EngagePurchaseRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use App\Nova\Actions\SyncEngagePurchaseRequestToQuickBooks;
+use App\Nova\Lenses\EngagePurchaseRequestsMissingExpenseReports;
+use App\Nova\Lenses\EngagePurchaseRequestsMissingInvoices;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
@@ -216,7 +218,10 @@ class EngagePurchaseRequest extends Resource
      */
     public function lenses(NovaRequest $request): array
     {
-        return [];
+        return [
+            EngagePurchaseRequestsMissingExpenseReports::make(),
+            EngagePurchaseRequestsMissingInvoices::make(),
+        ];
     }
 
     /**

--- a/app/Nova/ExpenseReport.php
+++ b/app/Nova/ExpenseReport.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Nova;
 
 use App\Nova\Actions\MatchExpenseReport;
-use App\Nova\Lenses\ExpenseReportsWithNoEnvelopes;
+use App\Nova\Lenses\ExpenseReportsWithNoEngagePurchaseRequests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Laravel\Nova\Fields\Badge;
@@ -174,7 +174,7 @@ class ExpenseReport extends Resource
     public function lenses(NovaRequest $request): array
     {
         return [
-            ExpenseReportsWithNoEnvelopes::make(),
+            ExpenseReportsWithNoEngagePurchaseRequests::make(),
         ];
     }
 

--- a/app/Nova/FiscalYear.php
+++ b/app/Nova/FiscalYear.php
@@ -74,6 +74,8 @@ class FiscalYear extends Resource
 
             HasMany::make('DocuSign Envelopes', 'envelopes'),
 
+            HasMany::make('Engage Requests', 'engagePurchaseRequests', EngagePurchaseRequest::class),
+
             HasMany::make('Expense Reports', 'expenseReports'),
 
             new Panel(

--- a/app/Nova/Lenses/EngagePurchaseRequestsMissingExpenseReports.php
+++ b/app/Nova/Lenses/EngagePurchaseRequestsMissingExpenseReports.php
@@ -63,6 +63,15 @@ class EngagePurchaseRequestsMissingExpenseReports extends Lens
                 ])
                 ->sortable(),
 
+            Badge::make('Status', 'status')
+                ->map([
+                    'Unapproved' => 'info',
+                    'Denied' => 'danger',
+                    'Canceled' => 'danger',
+                    'Approved' => 'success',
+                ])
+                ->sortable(),
+
             Text::make('Subject')
                 ->sortable(),
 

--- a/app/Nova/Lenses/EngagePurchaseRequestsMissingExpenseReports.php
+++ b/app/Nova/Lenses/EngagePurchaseRequestsMissingExpenseReports.php
@@ -4,46 +4,42 @@ declare(strict_types=1);
 
 namespace App\Nova\Lenses;
 
-use App\Models\DocuSignEnvelope;
-use App\Nova\User;
+use App\Models\EngagePurchaseRequest;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\URL;
 use Laravel\Nova\Http\Requests\LensRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Lenses\Lens;
 
-class ReimbursementsMissingExpenseReports extends Lens
+class EngagePurchaseRequestsMissingExpenseReports extends Lens
 {
     /**
      * The displayable name of the lens.
      *
      * @var string
      */
-    public $name = 'Reimbursements Missing Expense Reports';
+    public $name = 'Engage Requests Missing Expense Reports';
 
     /**
      * Get the query builder / paginator for the lens.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\DocuSignEnvelope>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\DocuSignEnvelope>
+     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\EngagePurchaseRequest>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\EngagePurchaseRequest>
      */
     public static function query(LensRequest $request, $query): Builder
     {
         return $request->withOrdering($request->withFilters(
             $query->whereDoesntHave('expenseReport')
-                ->whereDoesntHave('replacedBy')
-                ->whereDoesntHave('duplicateOf')
-                ->whereIn('type', ['purchase_reimbursement', 'travel_reimbursement'])
-                ->where('lost', '=', false)
-                ->where('internal_cost_transfer', '=', false)
-                ->where('submission_error', '=', false)
+                ->where(static function (Builder $query): void {
+                    $query->where('payee_first_name', 'like', '%robojackets%')
+                        ->orWhere('payee_last_name', 'like', '%robojackets%');
+                })
         ));
     }
 
@@ -55,37 +51,45 @@ class ReimbursementsMissingExpenseReports extends Lens
     public function fields(NovaRequest $request): array
     {
         return [
-            ID::make()
+            Number::make('Request Number', 'engage_request_number')
+                ->sortable(),
+
+            Badge::make('Step', 'current_step_name')
+                ->map([
+                    'Submitted' => 'info',
+                    'Send to SOFO Accountant' => 'info',
+                    'Sent back for edits' => 'danger',
+                    'Check Request Sent' => 'success',
+                ])
+                ->sortable(),
+
+            Text::make('Subject')
                 ->sortable(),
 
             DateTime::make('Submitted', 'submitted_at')
                 ->sortable(),
 
-            Select::make('Form Type', 'type')
-                ->sortable()
-                ->options(DocuSignEnvelope::$types)
-                ->displayUsingLabels(),
-
-            BelongsTo::make('Pay To', 'payToUser', User::class)
-                ->sortable()
-                ->nullable(),
-
-            Text::make('Description')
+            Currency::make('Submitted Amount')
                 ->sortable(),
 
-            Currency::make('Amount')
+            Currency::make('Approved Amount')
+                ->sortable(),
+
+            Text::make('Payee First Name', 'payee_first_name')
+                ->sortable(),
+
+            Text::make('Payee Last Name', 'payee_last_name')
                 ->sortable(),
 
             URL::make('QuickBooks Invoice', 'quickbooks_invoice_url')
                 ->displayUsing(
                     static fn (
                         $value,
-                        DocuSignEnvelope $resource,
+                        EngagePurchaseRequest $resource,
                         string $attribute
                     ): ?int => $resource->quickbooks_invoice_document_number
                 )
-                ->canSee(static fn (Request $request): bool => $request->user()->can('access-quickbooks'))
-                ->hideWhenUpdating(),
+                ->canSee(static fn (Request $request): bool => $request->user()->can('access-quickbooks')),
         ];
     }
 

--- a/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
+++ b/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
@@ -4,51 +4,43 @@ declare(strict_types=1);
 
 namespace App\Nova\Lenses;
 
-use App\Models\DocuSignEnvelope;
 use App\Nova\ExpenseReport;
 use Illuminate\Database\Eloquent\Builder;
+use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\LensRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Lenses\Lens;
 
-class ReimbursementsMissingInvoices extends Lens
+class EngagePurchaseRequestsMissingInvoices extends Lens
 {
     /**
      * The displayable name of the lens.
      *
      * @var string
      */
-    public $name = 'Reimbursements Missing Invoices';
+    public $name = 'Engage Requests Missing Invoices';
 
     /**
      * Get the query builder / paginator for the lens.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\DocuSignEnvelope>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\DocuSignEnvelope>
+     * @param  \Illuminate\Database\Eloquent\Builder<\App\Models\EngagePurchaseRequest>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<\App\Models\EngagePurchaseRequest>
      */
     public static function query(LensRequest $request, $query): Builder
     {
         return $request->withOrdering($request->withFilters(
             $query->whereNull('quickbooks_invoice_id')
-                ->whereDoesntHave('replacedBy')
-                ->whereDoesntHave('duplicateOf')
-                ->whereDoesntHave('payToUser')
-                ->whereHas(
-                    'fiscalYear',
-                    static function (Builder $query): void {
-                        $query->where('in_scope_for_quickbooks', '=', true);
-                    }
-                )
-                ->whereIn('type', ['purchase_reimbursement', 'travel_reimbursement'])
-                ->where('lost', '=', false)
-                ->where('internal_cost_transfer', '=', false)
-                ->where('submission_error', '=', false)
+                ->where(static function (Builder $query): void {
+                    $query->where('payee_first_name', 'like', '%robojackets%')
+                        ->orWhere('payee_last_name', 'like', '%robojackets%');
+                })
+                ->where('approved', '=', true)
+                ->where('current_step_name', '=', 'Check Request Sent')
         ));
     }
 
@@ -60,27 +52,39 @@ class ReimbursementsMissingInvoices extends Lens
     public function fields(NovaRequest $request): array
     {
         return [
-            ID::make()
+            Number::make('Request Number', 'engage_request_number')
+                ->sortable(),
+
+            Badge::make('Step', 'current_step_name')
+                ->map([
+                    'Submitted' => 'info',
+                    'Send to SOFO Accountant' => 'info',
+                    'Sent back for edits' => 'danger',
+                    'Check Request Sent' => 'success',
+                ])
+                ->sortable(),
+
+            Text::make('Subject')
                 ->sortable(),
 
             DateTime::make('Submitted', 'submitted_at')
                 ->sortable(),
 
-            Select::make('Form Type', 'type')
-                ->sortable()
-                ->options(DocuSignEnvelope::$types)
-                ->displayUsingLabels(),
-
-            Text::make('Description')
+            Currency::make('Submitted Amount')
                 ->sortable(),
 
-            Currency::make('Amount')
+            Currency::make('Approved Amount')
+                ->sortable(),
+
+            Text::make('Payee First Name', 'payee_first_name')
+                ->sortable(),
+
+            Text::make('Payee Last Name', 'payee_last_name')
                 ->sortable(),
 
             BelongsTo::make('Workday Expense Report', 'expenseReport', ExpenseReport::class)
                 ->sortable()
-                ->nullable()
-                ->searchable(),
+                ->nullable(),
         ];
     }
 

--- a/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
+++ b/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
@@ -39,7 +39,7 @@ class EngagePurchaseRequestsMissingInvoices extends Lens
                     $query->where('payee_first_name', 'like', '%robojackets%')
                         ->orWhere('payee_last_name', 'like', '%robojackets%');
                 })
-                ->where('approved', '=', true)
+                ->where('status', '=', 'Approved')
                 ->where('current_step_name', '=', 'Check Request Sent')
         ));
     }

--- a/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
+++ b/app/Nova/Lenses/EngagePurchaseRequestsMissingInvoices.php
@@ -64,6 +64,15 @@ class EngagePurchaseRequestsMissingInvoices extends Lens
                 ])
                 ->sortable(),
 
+            Badge::make('Status', 'status')
+                ->map([
+                    'Unapproved' => 'info',
+                    'Denied' => 'danger',
+                    'Canceled' => 'danger',
+                    'Approved' => 'success',
+                ])
+                ->sortable(),
+
             Text::make('Subject')
                 ->sortable(),
 

--- a/app/Nova/Lenses/ExpensePaymentsReadyToSyncToQuickBooks.php
+++ b/app/Nova/Lenses/ExpensePaymentsReadyToSyncToQuickBooks.php
@@ -38,7 +38,7 @@ class ExpensePaymentsReadyToSyncToQuickBooks extends Lens
                     'expenseReports',
                     static function (Builder $query): void {
                         $query->whereHas(
-                            'envelopes',
+                            'engagePurchaseRequests',
                             static function (Builder $query): void {
                                 $query->whereNull('quickbooks_invoice_id');
                             }
@@ -49,7 +49,7 @@ class ExpensePaymentsReadyToSyncToQuickBooks extends Lens
                     'expenseReports',
                     static function (Builder $query): void {
                         $query->whereHas(
-                            'envelopes',
+                            'engagePurchaseRequests',
                             static function (Builder $query): void {
                                 $query->whereHas(
                                     'fiscalYear',
@@ -61,6 +61,12 @@ class ExpensePaymentsReadyToSyncToQuickBooks extends Lens
                         );
                     }
                 )
+                ->whereHas(
+                    'bankTransaction',
+                    static function (Builder $query): void {
+                        $query->whereNotNull('transaction_posted_at');
+                    }
+                )
                 ->whereDoesntHave(
                     'payTo',
                     static function (Builder $query): void {
@@ -68,6 +74,7 @@ class ExpensePaymentsReadyToSyncToQuickBooks extends Lens
                     }
                 )
                 ->where('status', '=', 'Complete')
+                ->where('reconciled', '=', true)
         ));
     }
 

--- a/app/Nova/Lenses/ExpenseReportsWithNoEngagePurchaseRequests.php
+++ b/app/Nova/Lenses/ExpenseReportsWithNoEngagePurchaseRequests.php
@@ -7,6 +7,7 @@ namespace App\Nova\Lenses;
 use App\Nova\ExternalCommitteeMember;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
+use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Currency;
 use Laravel\Nova\Fields\Date;
@@ -53,7 +54,19 @@ class ExpenseReportsWithNoEngagePurchaseRequests extends Lens
             Date::make('Created', 'created_date')
                 ->sortable(),
 
-            Text::make('Status')
+            Badge::make('Status')
+                ->map([
+                    // @phan-suppress-next-line PhanTypeInvalidArrayKeyLiteral
+                    null => 'danger',
+                    'Draft' => 'info',
+                    'In Progress' => 'info',
+                    'Waiting on Gift Manager' => 'info',
+                    'Waiting on Cost Center Manager' => 'info',
+                    'Waiting on Expense Partner' => 'info',
+                    'Approved' => 'success',
+                    'Paid' => 'success',
+                    'Canceled' => 'danger',
+                ])
                 ->sortable(),
 
             BelongsTo::make('Pay To', 'payTo', ExternalCommitteeMember::class)

--- a/app/Nova/Lenses/ExpenseReportsWithNoEngagePurchaseRequests.php
+++ b/app/Nova/Lenses/ExpenseReportsWithNoEngagePurchaseRequests.php
@@ -15,14 +15,14 @@ use Laravel\Nova\Http\Requests\LensRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Lenses\Lens;
 
-class ExpenseReportsWithNoEnvelopes extends Lens
+class ExpenseReportsWithNoEngagePurchaseRequests extends Lens
 {
     /**
      * The displayable name of the lens.
      *
      * @var string
      */
-    public $name = 'Expense Reports with No Envelopes';
+    public $name = 'Expense Reports with No Requests';
 
     /**
      * Get the query builder / paginator for the lens.
@@ -34,6 +34,7 @@ class ExpenseReportsWithNoEnvelopes extends Lens
     {
         return $request->withOrdering($request->withFilters(
             $query->whereDoesntHave('envelopes')
+                ->whereDoesntHave('engagePurchaseRequests')
                 ->whereNotIn('status', ['Canceled', 'Paid'])
         ));
     }
@@ -92,6 +93,6 @@ class ExpenseReportsWithNoEnvelopes extends Lens
      */
     public function uriKey(): string
     {
-        return 'no-envelopes';
+        return 'no-requests';
     }
 }

--- a/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
+++ b/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
@@ -7,12 +7,14 @@ declare(strict_types=1);
 namespace App\Nova\Metrics;
 
 use App\Models\DocuSignEnvelope;
+use App\Models\ExpenseReport;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\JoinClause;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Value;
 use Laravel\Nova\Metrics\ValueResult;
+use function Clue\StreamFilter\fun;
 
 class AverageDaysToCreateExpenseReport extends Value
 {
@@ -30,7 +32,7 @@ class AverageDaysToCreateExpenseReport extends Value
      *
      * @var string
      */
-    public $helpText = 'Average number of calendar days between submission of a DocuSign form and creation of the expense report';
+    public $helpText = 'Average number of calendar days between submission of a reimbursement request and creation of the expense report';
 
     /**
      * Calculate the value of the metric.
@@ -42,17 +44,21 @@ class AverageDaysToCreateExpenseReport extends Value
         return $this->result(
             ceil(
                 floatval(
-                    DocuSignEnvelope::selectRaw(
-                        'avg(datediff(expense_reports.created_date, docusign_envelopes.submitted_at)) as diff'
+                    ExpenseReport::selectRaw(
+                        'avg(datediff(expense_reports.created_date, coalesce(docusign_envelopes.submitted_at, '.
+                        'engage_purchase_requests.submitted_at))) as diff',
                     )
-                        ->leftJoin('expense_reports', static function (JoinClause $join): void {
-                            $join->on('expense_reports.id', '=', 'expense_report_id');
+                        ->leftJoin('docusign_envelopes', static function (JoinClause $join): void {
+                            $join->on('docusign_envelopes.expense_report_id', '=', 'expense_reports.id');
+                        })
+                        ->leftJoin('engage_purchase_requests', static function (JoinClause $join): void {
+                            $join->on('engage_purchase_requests.expense_report_id', '=', 'expense_reports.id');
                         })
                         ->when(
                             $range !== 'ALL',
                             static function (EloquentBuilder $query, bool $range_is_not_all) use ($range): void {
                                 $query->where(
-                                    'docusign_envelopes.fiscal_year_id',
+                                    'expense_reports.fiscal_year_id',
                                     static function (QueryBuilder $query) use ($range) {
                                         $query->select('id')
                                             ->from('fiscal_years')
@@ -61,7 +67,10 @@ class AverageDaysToCreateExpenseReport extends Value
                                 );
                             }
                         )
-                        ->whereNotNull('created_date')
+                        ->where(static function (EloquentBuilder $query) {
+                            $query->whereNotNull('docusign_envelopes.id')
+                                ->orWhereNotNull('engage_purchase_requests.id');
+                        })
                         ->sole()->diff
                 )
             )

--- a/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
+++ b/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
@@ -44,7 +44,7 @@ class AverageDaysToCreateExpenseReport extends Value
                 floatval(
                     ExpenseReport::selectRaw(
                         'avg(datediff(expense_reports.created_date, coalesce(docusign_envelopes.submitted_at, '.
-                        'engage_purchase_requests.submitted_at))) as diff',
+                        'engage_purchase_requests.submitted_at))) as diff'
                     )
                         ->leftJoin('docusign_envelopes', static function (JoinClause $join): void {
                             $join->on('docusign_envelopes.expense_report_id', '=', 'expense_reports.id');

--- a/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
+++ b/app/Nova/Metrics/AverageDaysToCreateExpenseReport.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
 
 namespace App\Nova\Metrics;
 
-use App\Models\DocuSignEnvelope;
 use App\Models\ExpenseReport;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -14,7 +13,6 @@ use Illuminate\Database\Query\JoinClause;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Value;
 use Laravel\Nova\Metrics\ValueResult;
-use function Clue\StreamFilter\fun;
 
 class AverageDaysToCreateExpenseReport extends Value
 {

--- a/app/Nova/Metrics/EngagePurchaseRequestsMissingExpenseReports.php
+++ b/app/Nova/Metrics/EngagePurchaseRequestsMissingExpenseReports.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
 
 namespace App\Nova\Metrics;
 
-use App\Models\DocuSignEnvelope;
 use App\Models\EngagePurchaseRequest;
 use Illuminate\Database\Eloquent\Builder;
 use Laravel\Nova\Http\Requests\NovaRequest;

--- a/app/Nova/Metrics/EngagePurchaseRequestsMissingExpenseReports.php
+++ b/app/Nova/Metrics/EngagePurchaseRequestsMissingExpenseReports.php
@@ -7,11 +7,13 @@ declare(strict_types=1);
 namespace App\Nova\Metrics;
 
 use App\Models\DocuSignEnvelope;
+use App\Models\EngagePurchaseRequest;
+use Illuminate\Database\Eloquent\Builder;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Metrics\Value;
 use Laravel\Nova\Metrics\ValueResult;
 
-class DocuSignEnvelopesMissingExpenseReports extends Value
+class EngagePurchaseRequestsMissingExpenseReports extends Value
 {
     /**
      * The element's icon.
@@ -25,7 +27,7 @@ class DocuSignEnvelopesMissingExpenseReports extends Value
      *
      * @var string
      */
-    public $helpText = 'Purchase and travel reimbursement forms that have been submitted to SOFO, but have not been entered into Workday yet';
+    public $helpText = 'Engage requests that have been submitted in Engage, but have not been entered into Workday yet';
 
     /**
      * Calculate the value of the metric.
@@ -34,14 +36,13 @@ class DocuSignEnvelopesMissingExpenseReports extends Value
     {
         return $this
             ->result(
-                DocuSignEnvelope::selectRaw('coalesce(sum(amount), 0) as total')
+                EngagePurchaseRequest::selectRaw('coalesce(sum(submitted_amount), 0) as total')
                     ->whereDoesntHave('expenseReport')
-                    ->whereDoesntHave('replacedBy')
-                    ->whereDoesntHave('duplicateOf')
-                    ->whereDoesntHave('payToUser')
-                    ->whereIn('type', ['purchase_reimbursement', 'travel_reimbursement'])
-                    ->where('internal_cost_transfer', '=', false)
-                    ->where('lost', '=', false)
+                    ->where(static function (Builder $query): void {
+                        $query->where('payee_first_name', 'like', '%robojackets%')
+                            ->orWhere('payee_last_name', 'like', '%robojackets%');
+                    })
+                    ->whereNotNull('submitted_at')
                     ->sole()->total
             )
             ->dollars()
@@ -61,7 +62,7 @@ class DocuSignEnvelopesMissingExpenseReports extends Value
      */
     public function name(): string
     {
-        return 'Reimbursements Missing Expense Reports';
+        return 'Engage Requests Missing Expense Reports';
     }
 
     /**
@@ -69,6 +70,6 @@ class DocuSignEnvelopesMissingExpenseReports extends Value
      */
     public function uriKey(): string
     {
-        return 'docusign-envelopes-missing-expense-reports';
+        return 'engage-purchase-requests-missing-expense-reports';
     }
 }

--- a/app/Nova/Metrics/FiscalYearRanges.php
+++ b/app/Nova/Metrics/FiscalYearRanges.php
@@ -16,6 +16,7 @@ trait FiscalYearRanges
     public function ranges(): array
     {
         $ranges = FiscalYear::whereHas('envelopes')
+            ->orWhereHas('engagePurchaseRequests')
             ->get()
             ->sortByDesc('ending_year')
             ->mapWithKeys(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -86,7 +86,7 @@ parameters:
     - '#Parameter \#1 \$callback of method Tightenco\\Collect\\Support\\Collection<\(int\|string\),mixed>::filter\(\) expects \(callable\(mixed, int\|string\): bool\)\|null, Closure\(QuickBooksOnline\\API\\Data\\IPPReimburseCharge, int\): bool given\.#'
     - '#Parameter \#1 \$callback of method Tightenco\\Collect\\Support\\Collection<\(int\|string\),mixed>::map\(\) expects callable\(mixed, int\|string\): array, Closure\(array, string\): array given\.#'
     - '#Parameter \#1 \$callback of method Tightenco\\Collect\\Support\\Collection<\(int\|string\),mixed>::mapWithKeys\(\) expects callable\(mixed, int\|string\): array<string>, Closure\(QuickBooksOnline\\API\\Data\\IPPReimburseCharge, int\): non-empty-array<mixed, non-falsy-string> given\.#'
-    - '#Parameter \#1 \$displayCallback of method Laravel\\Nova\\Fields\\Field::displayUsing\(\) expects callable\(mixed, mixed, string\): mixed, Closure\(mixed, App\\Models\\DocuSignEnvelope, string\): \(int\|null\) given\.#'
+    - '#Parameter \#1 \$displayCallback of method Laravel\\Nova\\Fields\\Field::displayUsing\(\) expects callable\(mixed, mixed, string\): mixed, Closure\(mixed, App\\Models\\EngagePurchaseRequest, string\): \(int\|null\) given\.#'
     - '#Parameter \#1 \$displayCallback of method Laravel\\Nova\\Fields\\Field::displayUsing\(\) expects callable\(mixed, mixed, string\): mixed, Closure\(string\): string given\.#'
     - '#Parameter \#1 \$email of static method App\\Http\\Controllers\\EngagePurchaseRequestController::getUserByEmailAddress\(\) expects string, mixed given\.#'
     - '#Parameter \#1 \$entry of static method App\\Nova\\User::whitepagesEntryToString\(\) expects Adldap\\Models\\Entry, mixed given\.#'


### PR DESCRIPTION
- Top row metrics show data for Engage requests
- Bottom row metrics show data for FYs with either DocuSign envelopes or Engage requests
    - The calculation for these is a little bit different but the end result is still pretty close
- Lenses removed from DocuSign envelopes and added to Engage requests
    - Requests missing Workday expense reports
    - Requests missing QuickBooks invoices
- Expense report lens updated for Engage requests
    - Also swapped out status column for badge - closes #36